### PR TITLE
adding 200 response headers after a pull

### DIFF
--- a/GitAutoDeploy.py
+++ b/GitAutoDeploy.py
@@ -46,6 +46,7 @@ class GitAutoDeploy(BaseHTTPRequestHandler):
         body = self.rfile.read(length)
         post = urlparse.parse_qs(body)
         items = []
+        print post
         for itemString in post['payload']:
             item = json.loads(itemString)
             items.append(item['repository']['url'])

--- a/GitAutoDeploy.py
+++ b/GitAutoDeploy.py
@@ -44,12 +44,9 @@ class GitAutoDeploy(BaseHTTPRequestHandler):
     def parseRequest(self):
         length = int(self.headers.getheader('content-length'))
         body = self.rfile.read(length)
-        post = urlparse.parse_qs(body)
         items = []
-        print post
-        for itemString in post['payload']:
-            item = json.loads(itemString)
-            items.append(item['repository']['url'])
+        item = json.loads(body)
+        items.append(item['repository']['url'])
         return items
 
     def getMatchingPaths(self, repoUrl):

--- a/GitAutoDeploy.py
+++ b/GitAutoDeploy.py
@@ -39,6 +39,7 @@ class GitAutoDeploy(BaseHTTPRequestHandler):
             for path in paths:
                 self.pull(path)
                 self.deploy(path)
+        self.respond()
 
     def parseRequest(self):
         length = int(self.headers.getheader('content-length'))

--- a/GitAutoDeploy.py
+++ b/GitAutoDeploy.py
@@ -33,9 +33,9 @@ class GitAutoDeploy(BaseHTTPRequestHandler):
         return myClass.config
 
     def do_POST(self):
-        urls = self.parseRequest()
-        for url in urls:
-            paths = self.getMatchingPaths(url)
+        url_refs = self.parseRequest()
+        for url, ref in url_refs:
+            paths = self.getMatchingPaths(url, ref)
             for path in paths:
                 self.pull(path)
                 self.deploy(path)
@@ -48,14 +48,14 @@ class GitAutoDeploy(BaseHTTPRequestHandler):
         items = []
         for itemString in post['payload']:
             item = json.loads(itemString)
-            items.append(item['repository']['url'])
+            items.append((item['repository']['url'], item['ref']))
         return items
 
-    def getMatchingPaths(self, repoUrl):
+    def getMatchingPaths(self, repoUrl, ref):
         res = []
         config = self.getConfig()
         for repository in config['repositories']:
-            if(repository['url'] == repoUrl):
+            if(repository['url'] == repoUrl and repository.get('ref', '') in ('', ref)):
                 res.append(repository['path'])
         return res
 

--- a/GitAutoDeploy.py
+++ b/GitAutoDeploy.py
@@ -33,9 +33,9 @@ class GitAutoDeploy(BaseHTTPRequestHandler):
         return myClass.config
 
     def do_POST(self):
-        url_refs = self.parseRequest()
-        for url, ref in url_refs:
-            paths = self.getMatchingPaths(url, ref)
+        urls = self.parseRequest()
+        for url in urls:
+            paths = self.getMatchingPaths(url)
             for path in paths:
                 self.pull(path)
                 self.deploy(path)
@@ -48,14 +48,14 @@ class GitAutoDeploy(BaseHTTPRequestHandler):
         items = []
         for itemString in post['payload']:
             item = json.loads(itemString)
-            items.append((item['repository']['url'], item['ref']))
+            items.append(item['repository']['url'])
         return items
 
-    def getMatchingPaths(self, repoUrl, ref):
+    def getMatchingPaths(self, repoUrl):
         res = []
         config = self.getConfig()
         for repository in config['repositories']:
-            if(repository['url'] == repoUrl and repository.get('ref', '') in ('', ref)):
+            if(repository['url'] == repoUrl):
                 res.append(repository['path'])
         return res
 


### PR DESCRIPTION
For a project I'm working on it became necessary to access the last_response property from the giuthub api. 

When I looked, all hooks that were being answered by a Github-Auto-Deploy script were being recorded as 504 error responses instead of successes. 

So I added the line that invokes the existing response method to send a 200 header after a request is received.
