### PR TITLE
variable git command in conf file

### DIFF
--- a/GitAutoDeploy.conf.json.example
+++ b/GitAutoDeploy.conf.json.example
@@ -4,6 +4,7 @@
 	[{
 		"url": "https://github.com/logsol/Test-Repo", 
 		"path": "/home/logsol/projects/Test-Repo",
+		"gitcmd": "git fetch && git reset --hard origin/master && git clean -df && git checkout master",
 		"deploy": "echo deploying"
 	}, 
 	{

--- a/GitAutoDeploy.py
+++ b/GitAutoDeploy.py
@@ -80,7 +80,7 @@ class GitAutoDeploy(BaseHTTPRequestHandler):
         if(not self.quiet):
             print "\nPost push request received"
             print 'Updating ' + path
-        call(['cd "' + path + '" && git fetch'], shell=True)
+        call(['cd "' + path + '" && ' + repository['gitcmd']], shell=True)
 
     def deploy(self, path):
         config = self.getConfig()


### PR DESCRIPTION
I wanted to make sure that the working copy on my deployment system is always an exact copy of the newest revision at github/origin. 'git fetch' is insufficient for that reason.
Change 1: git command is part of the config file
Change 2: config example
Remark: example command is hardcore and will delete all local changes.
git checkout: is redundant here but needed if you want to define a git post-checkout hook (i have one)

Cheers!