### PR TITLE
Bitbucket support

### DIFF
--- a/GitAutoDeploy.conf.json.example
+++ b/GitAutoDeploy.conf.json.example
@@ -1,13 +1,16 @@
 {
-	"port": 8001, 
-	"repositories": 
-	[{
-		"url": "https://github.com/logsol/Test-Repo", 
+	"port": 8001,
+	"repositories": [{
+		"url": "https://github.com/logsol/Test-Repo",
 		"path": "/home/logsol/projects/Test-Repo",
 		"deploy": "echo deploying"
-	}, 
-	{
+	}, {
 		"url": "https://github.com/logsol/Katharsis-Framework",
 		"path": "/home/logsol/projects/Katharsis-Framework"
+	}, {
+		"branch": "name-of-branch",
+		"url": "https://bitbucket.org/team_name/repo_name",
+		"path": "/home/fouad/projects/webapp/beta",
+		"deploy": "git pull origin name-of-branch && service webapp restart"
 	}]
 }

--- a/test/bitbucket.json
+++ b/test/bitbucket.json
@@ -18,10 +18,10 @@
   "repository": {
     "links": {
       "self": {
-        "href": "https://api.bitbucket.org/api/2.0/repositories/bitbucket/bitbucket"
+        "href": "https://api.bitbucket.org/api/2.0/repositories/team_name/repo_name"
       },
       "html": {
-        "href": "https://api.bitbucket.org/bitbucket/bitbucket"
+        "href": "https://bitbucket.org/team_name/repo_name"
       },
       "avatar": {
         "href": "https://api-staging-assetroot.s3.amazonaws.com/c/photos/2014/Aug/01/bitbucket-logo-2629490769-3_avatar.png"
@@ -78,7 +78,7 @@
             "html": {
               "href": "https://bitbucket.org/user_name/repo_name/commits/c4b2b7914156a878aa7c9da452a09fb50c2091f2"
             }
-          },
+          }
         },
         "links": {
           "self": {

--- a/test/bitbucket.json
+++ b/test/bitbucket.json
@@ -1,0 +1,198 @@
+{
+  "actor": {
+    "username": "emmap1",
+    "display_name": "Emma",
+    "uuid": "{a54f16da-24e9-4d7f-a3a7-b1ba2cd98aa3}",
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/api/2.0/users/emmap1"
+      },
+      "html": {
+        "href": "https://api.bitbucket.org/emmap1"
+      },
+      "avatar": {
+        "href": "https://bitbucket-api-assetroot.s3.amazonaws.com/c/photos/2015/Feb/26/3613917261-0-emmap1-avatar_avatar.png"
+      }
+    }
+  },
+  "repository": {
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/api/2.0/repositories/bitbucket/bitbucket"
+      },
+      "html": {
+        "href": "https://api.bitbucket.org/bitbucket/bitbucket"
+      },
+      "avatar": {
+        "href": "https://api-staging-assetroot.s3.amazonaws.com/c/photos/2014/Aug/01/bitbucket-logo-2629490769-3_avatar.png"
+      }
+    },
+    "uuid": "{673a6070-3421-46c9-9d48-90745f7bfe8e}",
+    "full_name": "team_name/repo_name",
+    "name": "repo_name",
+    "scm": "git",
+    "is_private": true
+  },
+  "push": {
+    "changes": [{
+      "new": {
+        "type": "branch",
+        "name": "name-of-branch",
+        "target": {
+          "type": "commit",
+          "hash": "709d658dc5b6d6afcd46049c2f332ee3f515a67d",
+          "author": {
+            "username": "emmap1",
+            "display_name": "Emma",
+            "uuid": "{a54f16da-24e9-4d7f-a3a7-b1ba2cd98aa3}",
+            "links": {
+              "self": {
+                "href": "https://api.bitbucket.org/api/2.0/users/emmap1"
+              },
+              "html": {
+                "href": "https://api.bitbucket.org/emmap1"
+              },
+              "avatar": {
+                "href": "https://bitbucket-api-assetroot.s3.amazonaws.com/c/photos/2015/Feb/26/3613917261-0-emmap1-avatar_avatar.png"
+              }
+            }
+          },
+          "message": "new commit message\n",
+          "date": "2015-06-09T03:34:49+00:00",
+          "parents": [{
+            "type": "commit",
+            "hash": "1e65c05c1d5171631d92438a13901ca7dae9618c",
+            "links": {
+              "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/user_name/repo_name/commit/8cbbd65829c7ad834a97841e0defc965718036a0"
+              },
+              "html": {
+                "href": "https://bitbucket.org/user_name/repo_name/commits/8cbbd65829c7ad834a97841e0defc965718036a0"
+              }
+            }
+          }],
+          "links": {
+            "self": {
+              "href": "https://api.bitbucket.org/2.0/repositories/user_name/repo_name/commit/c4b2b7914156a878aa7c9da452a09fb50c2091f2"
+            },
+            "html": {
+              "href": "https://bitbucket.org/user_name/repo_name/commits/c4b2b7914156a878aa7c9da452a09fb50c2091f2"
+            }
+          },
+        },
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/user_name/repo_name/refs/branches/master"
+          },
+          "commits": {
+            "href": "https://api.bitbucket.org/2.0/repositories/user_name/repo_name/commits/master"
+          },
+          "html": {
+            "href": "https://bitbucket.org/user_name/repo_name/branch/master"
+          }
+        }
+      },
+      "old": {
+        "type": "branch",
+        "name": "name-of-branch",
+        "target": {
+          "type": "commit",
+          "hash": "1e65c05c1d5171631d92438a13901ca7dae9618c",
+          "author": {
+            "username": "emmap1",
+            "display_name": "Emma",
+            "uuid": "{a54f16da-24e9-4d7f-a3a7-b1ba2cd98aa3}",
+            "links": {
+              "self": {
+                "href": "https://api.bitbucket.org/api/2.0/users/emmap1"
+              },
+              "html": {
+                "href": "https://api.bitbucket.org/emmap1"
+              },
+              "avatar": {
+                "href": "https://bitbucket-api-assetroot.s3.amazonaws.com/c/photos/2015/Feb/26/3613917261-0-emmap1-avatar_avatar.png"
+              }
+            }
+          },
+          "message": "old commit message\n",
+          "date": "2015-06-08T21:34:56+00:00",
+          "parents": [{
+            "type": "commit",
+            "hash": "e0d0c2041e09746be5ce4b55067d5a8e3098c843",
+            "links": {
+              "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/user_name/repo_name/commit/9c4a3452da3bc4f37af5a6bb9c784246f44406f7"
+              },
+              "html": {
+                "href": "https://bitbucket.org/user_name/repo_name/commits/9c4a3452da3bc4f37af5a6bb9c784246f44406f7"
+              }
+            }
+          }],
+          "links": {
+            "self": {
+              "href": "https://api.bitbucket.org/2.0/repositories/user_name/repo_name/commit/b99ea6dad8f416e57c5ca78c1ccef590600d841b"
+            },
+            "html": {
+              "href": "https://bitbucket.org/user_name/repo_name/commits/b99ea6dad8f416e57c5ca78c1ccef590600d841b"
+            }
+          }
+        },
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/user_name/repo_name/refs/branches/master"
+          },
+          "commits": {
+            "href": "https://api.bitbucket.org/2.0/repositories/user_name/repo_name/commits/master"
+          },
+          "html": {
+            "href": "https://bitbucket.org/user_name/repo_name/branch/master"
+          }
+        }
+      },
+      "links": {
+        "html": {
+          "href": "https://bitbucket.org/user_name/repo_name/branches/compare/c4b2b7914156a878aa7c9da452a09fb50c2091f2..b99ea6dad8f416e57c5ca78c1ccef590600d841b"
+        },
+        "diff": {
+          "href": "https://api.bitbucket.org/2.0/repositories/user_name/repo_name/diff/c4b2b7914156a878aa7c9da452a09fb50c2091f2..b99ea6dad8f416e57c5ca78c1ccef590600d841b"
+        },
+        "commits": {
+          "href": "https://api.bitbucket.org/2.0/repositories/user_name/repo_name/commits?include=c4b2b7914156a878aa7c9da452a09fb50c2091f2&exclude=b99ea6dad8f416e57c5ca78c1ccef590600d841b"
+        }
+      },
+      "created": false,
+      "forced": false,
+      "closed": false,
+      "commits": [{
+        "hash": "03f4a7270240708834de475bcf21532d6134777e",
+        "type": "commit",
+        "message": "commit message\n",
+        "author": {
+          "username": "emmap1",
+          "display_name": "Emma",
+          "uuid": "{a54f16da-24e9-4d7f-a3a7-b1ba2cd98aa3}",
+          "links": {
+            "self": {
+              "href": "https://api.bitbucket.org/api/2.0/users/emmap1"
+            },
+            "html": {
+              "href": "https://api.bitbucket.org/emmap1"
+            },
+            "avatar": {
+              "href": "https://bitbucket-api-assetroot.s3.amazonaws.com/c/photos/2015/Feb/26/3613917261-0-emmap1-avatar_avatar.png"
+            }
+          }
+        },
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/user/repo/commit/03f4a7270240708834de475bcf21532d6134777e"
+          },
+          "html": {
+            "href": "https://bitbucket.org/user/repo/commits/03f4a7270240708834de475bcf21532d6134777e"
+          }
+        }
+      }],
+      "truncated": false
+    }]
+  }
+}

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,0 +1,3 @@
+
+# test bitbucket webhook
+curl -X POST -H "User-Agent: Bitbucket-Webhooks/2.0" -H "X-Request-UUID: d0fe7a78-8f44-4ce1-9af3-5af731113caa" -H "X-Event-Key: repo:push" -H "X-Attempt-Number: 1" -H "X-Hook-UUID: 0ae064cd-be16-4e85-9824-3fc68f967d16" -H "Content-Type: application/json" -d@bitbucket.json 'http://localhost:8001'


### PR DESCRIPTION
-  added bitbucket support for the *repo:push* webhook
used the User-Agent header to detect if the webhook was sent from BitBucket
- added an example to the conf file to show how it to track a bitbucket repo
- added a test script that sends a request to localhost using the bitbucket webooks schema